### PR TITLE
Avoid Unused method parameter (CR5)

### DIFF
--- a/src/main/java/org/example/ShoppingGUI.java
+++ b/src/main/java/org/example/ShoppingGUI.java
@@ -556,7 +556,8 @@ public class ShoppingGUI extends JFrame {
      * @param event - The ActionEvent object representing the button click event.
      */
 
-    private void showShoppingCart(ActionEvent event) {
+    @SuppressWarnings("unused")
+    private void showShoppingCart() {
 
         // Calculate the totals and update the cart display
         updateCartDisplay();


### PR DESCRIPTION
The unused parameter ActionEvent event in the showShoppingCart method is flagged. This parameter serves no purpose in the current implementation and needs to be removed for cleaner and more efficient code.